### PR TITLE
Add namespace variable for public-zone module

### DIFF
--- a/modules/public-zone/main.tf
+++ b/modules/public-zone/main.tf
@@ -3,7 +3,7 @@ locals {
     package = "terraform-aws-domain"
     version = trimspace(file("${path.module}/../../VERSION"))
     module  = basename(path.module)
-    name    = var.name
+    name    = "${var.namespace}/${var.name}"
   }
   module_tags = var.module_tags_enabled ? {
     "module.terraform.io/package"   = local.metadata.package

--- a/modules/public-zone/outputs.tf
+++ b/modules/public-zone/outputs.tf
@@ -13,6 +13,11 @@ output "name" {
   value       = aws_route53_zone.public.name
 }
 
+output "namespace" {
+  description = "The namespace of the Hosted Zone."
+  value       = var.namespace
+}
+
 output "comment" {
   description = "A comment for the Hosted Zone."
   value       = aws_route53_zone.public.comment

--- a/modules/public-zone/resource-group.tf
+++ b/modules/public-zone/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/public-zone/variables.tf
+++ b/modules/public-zone/variables.tf
@@ -1,36 +1,47 @@
 variable "name" {
-  description = "The name of the Hosted Zone."
+  description = "(Required) The name of the Hosted Zone."
   type        = string
+}
+
+variable "namespace" {
+  description = "(Optional) The namespace of the Hosted Zone. Just for categorising overlapped hosted zones."
+  type        = string
+  default     = "default"
+  nullable    = false
 }
 
 variable "comment" {
-  description = "A comment for the Hosted Zone."
+  description = "(Optional) A comment for the Hosted Zone."
   type        = string
   default     = "Managed by Terraform"
+  nullable    = false
 }
 
 variable "force_destroy" {
-  description = "Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone."
+  description = "(Optional) Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "delegation_set_id" {
-  description = "The ID of the reusable delegation set whose NS records you want to assign to the Hosted Zone."
+  description = "(Optional) The ID of the reusable delegation set whose NS records you want to assign to the Hosted Zone."
   type        = string
   default     = null
 }
 
 variable "tags" {
-  description = "A map of tags to add to all resources."
+  description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
-  description = "Whether to create AWS Resource Tags for the module informations."
+  description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -39,19 +50,22 @@ variable "module_tags_enabled" {
 ###################################################
 
 variable "resource_group_enabled" {
-  description = "Whether to create Resource Group to find and group AWS resources which are created by this module."
+  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
-  description = "The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
+  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
-  description = "The description of Resource Group."
+  description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/public-zone/versions.tf
+++ b/modules/public-zone/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.56"
+      version = ">= 4.22"
     }
   }
 }


### PR DESCRIPTION
### Background

- Add namespace variable for public-zone module
  - Because user can create multiple public hosted zones with duplicated names.