### PR TITLE
Support dummy vpc for private-zone module

### DIFF
--- a/modules/private-zone/README.md
+++ b/modules/private-zone/README.md
@@ -5,6 +5,7 @@ This module creates following resources.
 - `aws_route53_zone`
 - `aws_route53_zone_vpc_association` (optional)
 - `aws_route53_vpc_association_authorization` (optional)
+- `aws_vpc` (optional)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/private-zone/resource-group.tf
+++ b/modules/private-zone/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/private-zone/variables.tf
+++ b/modules/private-zone/variables.tf
@@ -1,54 +1,62 @@
 variable "name" {
-  description = "The name of the Hosted Zone."
+  description = "(Required) The name of the Hosted Zone."
   type        = string
 }
 
 variable "namespace" {
-  description = "The namespace of the Hosted Zone. Just for categorising overlapped hosted zones."
+  description = "(Optional) The namespace of the Hosted Zone. Just for categorising overlapped hosted zones."
   type        = string
   default     = "default"
+  nullable    = false
 }
 
 variable "comment" {
-  description = "A comment for the Hosted Zone."
+  description = "(Optional) A comment for the Hosted Zone."
   type        = string
   default     = "Managed by Terraform"
+  nullable    = false
 }
 
 variable "force_destroy" {
-  description = "Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone."
+  description = "(Optional) Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "authorized_cross_account_vpc_associations" {
-  description = "Authorizes a VPC in a peer account to be associated with a local Route53 Hosted Zone. `vpc_id` is required to authorize for association with the private Hosted Zone. `region` is optional. Defaults to the region of the AWS provider."
+  description = "(Optional) Authorizes a VPC in a peer account to be associated with a local Route53 Hosted Zone. `vpc_id` is required to authorize for association with the private Hosted Zone. `region` is optional. Defaults to the region of the AWS provider."
   type        = list(map(string))
   default     = []
+  nullable    = false
 }
 
 variable "primary_vpc_association" {
-  description = "The Primary VPC to associate with the private hosted zone. `vpc_id` is required to associate with the private Hosted Zone. `region` is optional. Defaults to the region of the AWS provider."
+  description = "(Optional) The Primary VPC to associate with the private hosted zone. `vpc_id` is required to associate with the private Hosted Zone. `region` is optional. Defaults to the region of the AWS provider."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "secondary_vpc_associations" {
-  description = "A list of secondary VPCs to associate with the private hosted zone. `vpc_id` is required to associate with the private Hosted Zone. `region` is optional. Defaults to the region of the AWS provider."
+  description = "(Optional) A list of secondary VPCs to associate with the private hosted zone. `vpc_id` is required to associate with the private Hosted Zone. `region` is optional. Defaults to the region of the AWS provider."
   type        = list(map(string))
   default     = []
+  nullable    = false
 }
 
 variable "tags" {
-  description = "A map of tags to add to all resources."
+  description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
-  description = "Whether to create AWS Resource Tags for the module informations."
+  description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -57,19 +65,22 @@ variable "module_tags_enabled" {
 ###################################################
 
 variable "resource_group_enabled" {
-  description = "Whether to create Resource Group to find and group AWS resources which are created by this module."
+  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
-  description = "The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
+  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
-  description = "The description of Resource Group."
+  description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/private-zone/versions.tf
+++ b/modules/private-zone/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.56"
+      version = ">= 4.22"
     }
   }
 }


### PR DESCRIPTION
### Background

- Support dummy vpc for private-zone module
  - `data.aws_vpc.default` can be failed when the account already deleted the default vpc.