### PR TITLE
Support ram shares for resolver-query-logging module

### DIFF
--- a/modules/resolver-query-logging/README.md
+++ b/modules/resolver-query-logging/README.md
@@ -4,26 +4,30 @@ This module creates following resources.
 
 - `aws_route53_resolver_query_log_config`
 - `aws_route53_resolver_query_log_config_association` (optional)
+- `aws_ram_resource_share` (optional)
+- `aws_ram_principal_association` (optional)
+- `aws_ram_resource_association` (optional)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.40.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
+| <a name="module_share"></a> [share](#module\_share) | tedilabs/account/aws//modules/ram-share | ~> 0.22.0 |
 
 ## Resources
 
@@ -36,24 +40,25 @@ This module creates following resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_destination_arn"></a> [destination\_arn](#input\_destination\_arn) | (Required) The ARN of the resource that you want Route 53 Resolver to send query logs. You can send query logs to an S3 bucket, a CloudWatch Logs log group, or a Kinesis Data Firehose delivery stream. | `string` | n/a | yes |
+| <a name="input_destination"></a> [destination](#input\_destination) | (Required) The ARN of the resource that you want Route 53 Resolver to send query logs. You can send query logs to an S3 bucket, a CloudWatch Logs log group, or a Kinesis Data Firehose delivery stream. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the Route 53 Resolver query logging configuration. | `string` | n/a | yes |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_shares"></a> [shares](#input\_shares) | (Optional) A list of resource shares via RAM (Resource Access Manager). | <pre>list(object({<br>    name = optional(string)<br><br>    permissions = optional(set(string), ["AWSRAMDefaultPermissionResolverQueryLogConfig"])<br><br>    external_principals_allowed = optional(bool, false)<br>    principals                  = optional(set(string), [])<br><br>    tags = optional(map(string), {})<br>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
-| <a name="input_vpc_ids"></a> [vpc\_ids](#input\_vpc\_ids) | (Optional) List of VPC IDs that you want this query logging configuration to log queries for. | `list(string)` | `[]` | no |
+| <a name="input_vpc_associations"></a> [vpc\_associations](#input\_vpc\_associations) | (Optional) A list of VPC IDs that you want this query logging configuration to log queries for. | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the Route 53 Resolver query logging configuration. |
-| <a name="output_destination_arn"></a> [destination\_arn](#output\_destination\_arn) | The ARN of the resource that Route 53 Resolver send query logs. This can be S3 bucket, CloudWatch Logs log group, or Kinesis Data Firehose delivery stream. |
+| <a name="output_destination"></a> [destination](#output\_destination) | The ARN of the resource that Route 53 Resolver send query logs. This can be S3 bucket, CloudWatch Logs log group, or Kinesis Data Firehose delivery stream. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of the Route 53 Resolver query logging configuration. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the Route 53 Resolver query logging configuration. |
 | <a name="output_owner_id"></a> [owner\_id](#output\_owner\_id) | The AWS Account ID the account that created the query logging configuration. |
-| <a name="output_share_status"></a> [share\_status](#output\_share\_status) | An indication of whether the query logging configuration is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`. |
-| <a name="output_vpc_ids"></a> [vpc\_ids](#output\_vpc\_ids) | A list of associated VPC IDs to query logging configuration. |
+| <a name="output_sharing"></a> [sharing](#output\_sharing) | The configuration for sharing of the Route53 Resolver query logging configuration.<br>    `status` - An indication of whether the query logging configuration is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`.<br>    `shares` - The list of resource shares via RAM (Resource Access Manager). |
+| <a name="output_vpc_associations"></a> [vpc\_associations](#output\_vpc\_associations) | A list of associated VPC IDs to query logging configuration. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/resolver-query-logging/main.tf
+++ b/modules/resolver-query-logging/main.tf
@@ -16,7 +16,7 @@ locals {
 
 resource "aws_route53_resolver_query_log_config" "this" {
   name            = local.metadata.name
-  destination_arn = var.destination_arn
+  destination_arn = var.destination
 
   tags = merge(
     {
@@ -28,7 +28,7 @@ resource "aws_route53_resolver_query_log_config" "this" {
 }
 
 resource "aws_route53_resolver_query_log_config_association" "this" {
-  for_each = toset(var.vpc_ids)
+  for_each = toset(var.vpc_associations)
 
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.this.id
   resource_id                  = each.value

--- a/modules/resolver-query-logging/outputs.tf
+++ b/modules/resolver-query-logging/outputs.tf
@@ -18,17 +18,24 @@ output "name" {
   value       = aws_route53_resolver_query_log_config.this.name
 }
 
-output "share_status" {
-  description = "An indication of whether the query logging configuration is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`."
-  value       = aws_route53_resolver_query_log_config.this.share_status
-}
-
-output "vpc_ids" {
+output "vpc_associations" {
   description = "A list of associated VPC IDs to query logging configuration."
-  value       = var.vpc_ids
+  value       = keys(aws_route53_resolver_query_log_config_association.this)
 }
 
-output "destination_arn" {
+output "destination" {
   description = "The ARN of the resource that Route 53 Resolver send query logs. This can be S3 bucket, CloudWatch Logs log group, or Kinesis Data Firehose delivery stream."
-  value       = var.destination_arn
+  value       = aws_route53_resolver_query_log_config.this.destination_arn
+}
+
+output "sharing" {
+  description = <<EOF
+  The configuration for sharing of the Route53 Resolver query logging configuration.
+    `status` - An indication of whether the query logging configuration is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`.
+    `shares` - The list of resource shares via RAM (Resource Access Manager).
+  EOF
+  value = {
+    status = aws_route53_resolver_query_log_config.this.share_status
+    shares = module.share
+  }
 }

--- a/modules/resolver-query-logging/ram-shares.tf
+++ b/modules/resolver-query-logging/ram-shares.tf
@@ -1,0 +1,32 @@
+###################################################
+# Resource Sharing by RAM (Resource Access Manager)
+###################################################
+
+module "share" {
+  source  = "tedilabs/account/aws//modules/ram-share"
+  version = "~> 0.22.0"
+
+  for_each = {
+    for share in var.shares :
+    share.name => share
+  }
+
+  name = "route53-resolver.query-log-config.${var.name}.${each.key}"
+
+  resources = [
+    aws_route53_resolver_query_log_config.this.arn,
+  ]
+  permissions = each.value.permissions
+
+  external_principals_allowed = each.value.external_principals_allowed
+  principals                  = each.value.principals
+
+  resource_group_enabled = false
+  module_tags_enabled    = false
+
+  tags = merge(
+    local.module_tags,
+    var.tags,
+    each.value.tags,
+  )
+}

--- a/modules/resolver-query-logging/variables.tf
+++ b/modules/resolver-query-logging/variables.tf
@@ -3,13 +3,13 @@ variable "name" {
   type        = string
 }
 
-variable "destination_arn" {
+variable "destination" {
   description = "(Required) The ARN of the resource that you want Route 53 Resolver to send query logs. You can send query logs to an S3 bucket, a CloudWatch Logs log group, or a Kinesis Data Firehose delivery stream."
   type        = string
 }
 
-variable "vpc_ids" {
-  description = "(Optional) List of VPC IDs that you want this query logging configuration to log queries for."
+variable "vpc_associations" {
+  description = "(Optional) A list of VPC IDs that you want this query logging configuration to log queries for."
   type        = list(string)
   default     = []
   nullable    = false
@@ -53,4 +53,25 @@ variable "resource_group_description" {
   type        = string
   default     = "Managed by Terraform."
   nullable    = false
+}
+
+
+###################################################
+# Resource Sharing by RAM (Resource Access Manager)
+###################################################
+
+variable "shares" {
+  description = "(Optional) A list of resource shares via RAM (Resource Access Manager)."
+  type = list(object({
+    name = optional(string)
+
+    permissions = optional(set(string), ["AWSRAMDefaultPermissionResolverQueryLogConfig"])
+
+    external_principals_allowed = optional(bool, false)
+    principals                  = optional(set(string), [])
+
+    tags = optional(map(string), {})
+  }))
+  default  = []
+  nullable = false
 }

--- a/modules/resolver-query-logging/versions.tf
+++ b/modules/resolver-query-logging/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Background

- Support resource sharing of `resolver-query-logging` module.