### PR TITLE
feat: improve how to use resource_group in modules

### DIFF
--- a/modules/amazon-issued-cert/outputs.tf
+++ b/modules/amazon-issued-cert/outputs.tf
@@ -94,3 +94,19 @@ output "renewal" {
     summary     = aws_acm_certificate.this.renewal_summary
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/amazon-issued-cert/resource-group.tf
+++ b/modules/amazon-issued-cert/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/amazon-issued-cert/variables.tf
+++ b/modules/amazon-issued-cert/variables.tf
@@ -93,23 +93,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/imported-cert/outputs.tf
+++ b/modules/imported-cert/outputs.tf
@@ -42,3 +42,19 @@ output "expiration_date" {
   description = "Expiration date and time of the certificate."
   value       = aws_acm_certificate.this.not_after
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/imported-cert/resource-group.tf
+++ b/modules/imported-cert/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/imported-cert/variables.tf
+++ b/modules/imported-cert/variables.tf
@@ -42,23 +42,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/private-ca-issued-cert/outputs.tf
+++ b/modules/private-ca-issued-cert/outputs.tf
@@ -55,3 +55,19 @@ output "expiration_date" {
   description = "Expiration date and time of the certificate."
   value       = aws_acm_certificate.this.not_after
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/private-ca-issued-cert/resource-group.tf
+++ b/modules/private-ca-issued-cert/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/private-ca-issued-cert/variables.tf
+++ b/modules/private-ca-issued-cert/variables.tf
@@ -54,23 +54,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/private-zone/outputs.tf
+++ b/modules/private-zone/outputs.tf
@@ -52,3 +52,19 @@ output "cross_account_vpc_association_authorizations" {
     }
   ]
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/private-zone/resource-group.tf
+++ b/modules/private-zone/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/private-zone/variables.tf
+++ b/modules/private-zone/variables.tf
@@ -86,23 +86,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/public-zone/outputs.tf
+++ b/modules/public-zone/outputs.tf
@@ -65,3 +65,19 @@ output "ns_records" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/public-zone/resource-group.tf
+++ b/modules/public-zone/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/public-zone/variables.tf
+++ b/modules/public-zone/variables.tf
@@ -81,23 +81,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/registered-domain/outputs.tf
+++ b/modules/registered-domain/outputs.tf
@@ -168,3 +168,19 @@ output "updated_at" {
 #     if !contains(["id", "domain_name", "tags", "tags_all", "auto_renew", "transfer_lock", "timeouts", "creation_date", "expiration_date", "updated_date", "registrar_name", "registrar_url", "whois_server", "reseller", "abuse_contact_email", "abuse_contact_phone", "admin_contact", "registrant_contact", "tech_contact", "admin_privacy", "registrant_privacy", "tech_privacy", "billing_contact", "billing_privacy", "status_list"], k)
 #   }
 # }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/registered-domain/resource-group.tf
+++ b/modules/registered-domain/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/registered-domain/variables.tf
+++ b/modules/registered-domain/variables.tf
@@ -346,23 +346,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/resolver-inbound-endpoint/outputs.tf
+++ b/modules/resolver-inbound-endpoint/outputs.tf
@@ -79,3 +79,19 @@ output "subnets" {
 #     if !contains(["id", "arn", "direction", "name", "host_vpc_id", "security_group_ids", "protocols", "resolver_endpoint_type", "tags", "tags_all", "ip_address", "timeouts"], k)
 #   }
 # }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/resolver-inbound-endpoint/resource-group.tf
+++ b/modules/resolver-inbound-endpoint/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/resolver-inbound-endpoint/variables.tf
+++ b/modules/resolver-inbound-endpoint/variables.tf
@@ -178,23 +178,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/resolver-query-logging/outputs.tf
+++ b/modules/resolver-query-logging/outputs.tf
@@ -39,3 +39,19 @@ output "sharing" {
     shares = module.share
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/resolver-query-logging/resource-group.tf
+++ b/modules/resolver-query-logging/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/resolver-query-logging/variables.tf
+++ b/modules/resolver-query-logging/variables.tf
@@ -34,26 +34,8 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
-}
 
 
 ###################################################
@@ -73,5 +55,21 @@ variable "shares" {
     tags = optional(map(string), {})
   }))
   default  = []
+  nullable = false
+}
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
   nullable = false
 }


### PR DESCRIPTION
## Summary
Update resource group configuration to use object-based pattern.

## Changes
- Update module version from ~> 0.10.0 to ~> 0.12.0
- Replace individual resource_group_* variables with single object variable  
- Update all references to use var.resource_group.* structure
- Add resource_group output to each module

## Modules Updated
- amazon-issued-cert
- imported-cert
- private-ca-issued-cert
- private-zone
- public-zone
- registered-domain
- resolver-inbound-endpoint
- resolver-query-logging

## Test Plan
- [ ] Review variable changes
- [ ] Verify resource-group module references are correct  
- [ ] Check outputs are properly formatted