### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/route53-private-zone-simple/main.tf
+++ b/examples/route53-private-zone-simple/main.tf
@@ -14,7 +14,7 @@ data "aws_vpc" "default" {
 module "zone" {
   source = "../../modules/private-zone/"
   # source  = "tedilabs/domain/aws//modules/private-zone"
-  # version = "~> 0.2.0"
+  # version = "~> 1.0.0"
 
   name = "mycompany.com"
 

--- a/examples/route53-public-zone-simple/main.tf
+++ b/examples/route53-public-zone-simple/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "zone" {
   source = "../../modules/public-zone/"
   # source  = "tedilabs/domain/aws//modules/public-zone"
-  # version = "~> 0.2.0"
+  # version = "~> 1.0.0"
 
   name = "mycompany.com"
 

--- a/modules/profile/ram-shares.tf
+++ b/modules/profile/ram-shares.tf
@@ -12,7 +12,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :

--- a/modules/resolver-inbound-endpoint/security-group.tf
+++ b/modules/resolver-inbound-endpoint/security-group.tf
@@ -23,7 +23,7 @@ data "aws_subnet" "this" {
 
 module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.0.0"
+  version = "~> 1.2.0"
 
   count = var.default_security_group.enabled ? 1 : 0
 

--- a/modules/resolver-query-logging/ram-shares.tf
+++ b/modules/resolver-query-logging/ram-shares.tf
@@ -13,7 +13,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :


### PR DESCRIPTION
## What & why

The `version` constraints on sibling tedilabs child modules in this repo had drifted well behind those modules' latest releases — `network/aws//modules/security-group` was pinned to the `1.0.x` line (latest is v1.2.3) and `organization/aws//modules/ram-share` to the `0.5.x` line (latest is v0.7.5). This PR realigns every such constraint to the house `~> MAJOR.MINOR.0` minor-floor convention, so each resolves to the newest patch in the current minor line.

It also refreshes the commented-out registry `# version` lines in `examples/`, which still advertised `~> 0.2.0` for this repo's own modules even though `terraform-aws-domain` has since reached v1.0.3.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/network/aws//modules/security-group` | `modules/resolver-inbound-endpoint/security-group.tf` | `~> 1.0.0` | `~> 1.2.0` | v1.2.3 |
| `tedilabs/organization/aws//modules/ram-share` | `modules/profile/ram-shares.tf` | `~> 0.5.0` | `~> 0.7.0` | v0.7.5 |
| `tedilabs/organization/aws//modules/ram-share` | `modules/resolver-query-logging/ram-shares.tf` | `~> 0.5.0` | `~> 0.7.0` | v0.7.5 |

### Example docs (commented)

These are commented-out registry alternatives; the active `source` in each example is the local `../../modules/<x>` path, so nothing resolvable changes. They are documentation for consumers.

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/domain/aws//modules/private-zone` (self) | `examples/route53-private-zone-simple/main.tf` | `~> 0.2.0` | `~> 1.0.0` | v1.0.3 |
| `tedilabs/domain/aws//modules/public-zone` (self) | `examples/route53-public-zone-simple/main.tf` | `~> 0.2.0` | `~> 1.0.0` | v1.0.3 |

## Interface changes between the old and new versions

### `tedilabs/network/aws//modules/security-group` — v1.0.2 → v1.2.3

Compare: https://github.com/tedilabs/terraform-aws-network/compare/v1.0.2...v1.2.3

**Verdict: BACKWARD_COMPATIBLE. No calling code changed.**

- **Added variables:** none.
- **Removed variables:** none.
- **Retyped variables:** one, and it is a pure relaxation — `from_port` and `to_port` inside the `ingress_rules` / `egress_rules` element objects went from required `number` to `optional(number)`. Every value shape valid at v1.0.2 is still valid at v1.2.3. Our call site in `modules/resolver-inbound-endpoint/security-group.tf` sets both `from_port = 53` and `to_port = 53` explicitly, so it is unaffected.
- **Outputs:** none added, removed, or renamed.
- **Version floors:** unchanged — `required_version = ">= 1.12"`, `hashicorp/aws >= 6.12` at both tags. No new floor is introduced, so this repo's own `versions.tf` needs no edit.

One operational note that does **not** apply here: between v1.0.2 and v1.2.3, the security-group module's *internal* RAM share changed `resources` from a list to a map keyed by `var.name`, and now sanitises the share name through `replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-")`. That only produces plan churn for callers that pass `shares` to the module. **This repo's call site does not set `shares` at all** (`grep -rn shares modules/resolver-inbound-endpoint/` returns nothing), and `shares` defaults to `[]`, which leaves `module.share` with zero instances. So there is no RAM-share churn from this bump.

### `tedilabs/organization/aws//modules/ram-share` — v0.5.6 → v0.7.5

Compare: https://github.com/tedilabs/terraform-aws-organization/compare/v0.5.6...v0.7.5

**Verdict: NO_INTERFACE_CHANGE. There is genuinely nothing to react to.**

The entire `modules/ram-share` directory is byte-identical at the two tags — not merely the interface files. The git tree object for the directory is the same hash (`63ef8ac74eb52b71cfe897f4d5ecd7ecb9e7c195`) at both v0.5.6 and v0.7.5, `git diff v0.5.6..v0.7.5 -- modules/ram-share/` is empty, and `git log v0.5.6..v0.7.5 -- modules/ram-share/` lists no commits. The releases in between changed other modules in that repo (mostly `organization-policy`), not this one.

Accordingly: no variables added, removed, or renamed; no output changes; no version floor change (`required_version = ">= 1.12"`, `aws >= 6.12` at both tags — already present at v0.5.6). Both of our call sites already pass the current-style `resources` map and a sanitised `name` prefix, so they need no edits.

## Verification

- `terraform fmt -recursive -check .` — passes.
- `terraform init -backend=false` + `terraform validate` in each of the three changed module directories, all **successful**:
  - `modules/profile` — `Success! The configuration is valid.`
  - `modules/resolver-inbound-endpoint` — `Success! The configuration is valid.`
  - `modules/resolver-query-logging` — `Success! The configuration is valid.`
- The new constraints were confirmed to resolve against the real registry. From `.terraform/modules/modules.json` after init:
  - `security_group` → **1.2.3** (`~> 1.2.0`)
  - `share` → **0.7.5** (`~> 0.7.0`), in both `modules/profile` and `modules/resolver-query-logging`
- All `.terraform/` directories and `.terraform.lock.hcl` files created during verification were removed before committing; `git status --porcelain` shows only the five intended files.

Not verified: no `terraform plan` or `apply` was run, so this PR does not prove an empty plan against live infrastructure — that requires AWS credentials and real state. Based on the interface analysis above an empty plan is expected for both bumps. The two `examples/` edits touch only comments and are therefore unverifiable by tooling by construction; the examples' active `source` remains the local module path.

## Supersedes

Three open dependabot PRs cover the same three constraints:

| PR | Constraint it proposes | Path |
|---|---|---|
| #69 | `tedilabs/network/aws` `~> 1.0.0` → `~> 1.2.2` | `/modules/resolver-inbound-endpoint` |
| #70 | `tedilabs/organization/aws` `~> 0.5.0` → `~> 0.6.4` | `/modules/profile` |
| #71 | `tedilabs/organization/aws` `~> 0.5.0` → `~> 0.6.4` | `/modules/resolver-query-logging` |

This PR supersedes all three, for two reasons:

1. **Dependabot pins the exact patch instead of the house minor floor.** #69 would write `~> 1.2.2`, which pins the patch and would need another PR for v1.2.3; this repo's convention is `~> 1.2.0`, the minor floor, which already resolves to v1.2.3 and will pick up future 1.2.x patches without churn.
2. **Dependabot's own targets are already stale, and #70/#71 undershoot a minor line.** They propose `~> 0.6.4` when `terraform-aws-organization` is at v0.7.5, so merging them would leave the constraint a full minor behind and require a follow-up. This PR goes straight to `~> 0.7.0`.

Additionally, none of the three touches the commented registry examples under `examples/`, which dependabot does not parse.

Leaving #69, #70 and #71 open — not closing them here.
