### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/route53-private-zone-simple/versions.tf
+++ b/examples/route53-private-zone-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/route53-public-zone-simple/versions.tf
+++ b/examples/route53-public-zone-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

Both `examples/*` roots fail `terraform init` on `main`: their `versions.tf` still pins
`aws = "~> 5.0"`, while the modules they call require `>= 6.12` and the `resource-group` child module
(`tedilabs/misc/aws` `~> 0.12.0`) requires `>= 6.0.0`. The constraint set is unsatisfiable, so
provider installation fails before anything else can be checked. `required_version` was also still
`~> 1.6` against modules that require `>= 1.12`.

This is the same fix that landed in the sibling repos as "correct terraform and provider version
constraints" — that sweep never covered this repo. All 8 `modules/*` dirs were already clean; this PR
touches only the two example `versions.tf` files.

## Validation matrix

Every `modules/*` and `examples/*` dir, `terraform fmt -check` / `terraform init -backend=false` /
`terraform validate` (Terraform v1.15.6, hashicorp/aws 6.58.0). `validate` is reported as `skip` when
`init` failed, because provider installation never completed.

| Dir | fmt before | init before | validate before | fmt after | init after | validate after |
|---|---|---|---|---|---|---|
| `modules/cidr-collection` | pass | pass | pass | pass | pass | pass |
| `modules/private-zone` | pass | pass | pass | pass | pass | pass |
| `modules/profile` | pass | pass | pass | pass | pass | pass |
| `modules/public-zone` | pass | pass | pass | pass | pass | pass |
| `modules/record-set` | pass | pass | pass | pass | pass | pass |
| `modules/registered-domain` | pass | pass | pass | pass | pass | pass |
| `modules/resolver-inbound-endpoint` | pass | pass | pass | pass | pass | pass |
| `modules/resolver-query-logging` | pass | pass | pass | pass | pass | pass |
| `examples/route53-private-zone-simple` | pass | **FAIL** | skip | pass | pass | pass |
| `examples/route53-public-zone-simple` | pass | **FAIL** | skip | pass | pass | pass |

`terraform fmt -recursive -check .` at the repo root: clean before and after.

## Changes

Both `examples/route53-private-zone-simple/versions.tf` and
`examples/route53-public-zone-simple/versions.tf`:

```diff
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"

   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }
```

The error being fixed:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 5.0, >= 6.0.0, >= 6.12.0
```

Where each constraint comes from:

| Constraint | Source |
|---|---|
| `~> 5.0` | the example's own `versions.tf` (this is the wrong one) |
| `>= 6.0.0` | `tedilabs/misc/aws//modules/resource-group` `0.12.0`, pulled in by the zone modules |
| `>= 6.12.0` | `modules/private-zone/versions.tf` and `modules/public-zone/versions.tf` |

`required_version` follows the same reasoning: the zone modules declare `>= 1.12`, so an example
pinned to `~> 1.6` could not run them either. New values follow the house convention already used
across the sibling repos — terraform `~> x.y`, providers `~> x.0`.

No example HCL other than the constraints needed changing: `module "zone"` in both roots matches the
current `variables.tf` of `modules/private-zone` / `modules/public-zone` (including
`primary_vpc_association`, which is required and is passed).

## Still failing

Nothing. All 8 `modules/*` and both `examples/*` dirs pass fmt + init + validate after this PR.

## Verification

- `terraform fmt -check`, `terraform init -backend=false`, `terraform validate` in all 8 `modules/*`
  and both `examples/*` dirs, before and after, with `.terraform` / `.terraform.lock.hcl` removed
  between dirs. Results are the matrix above.
- `terraform fmt -recursive -check .` at the repo root.
- No `*.md` in this repo contains an HCL example that calls a module
  (`grep -rn 'source *=' --include='*.md'` finds nothing), so there were no README blocks to check.
- Not verified: no `terraform plan`/`apply` was run — nothing here is checked against the real Route53
  API, only that the configuration loads and type-checks.
- Pre-existing deprecation warnings elsewhere in the repo family (e.g. `data.aws_region.this.name` is
  deprecated in favour of `region`) are untouched; they are warnings and do not fail `validate`.
