### PR TITLE
feat(profile): support resolver query log configuration associations

### DIFF
--- a/modules/profile/README.md
+++ b/modules/profile/README.md
@@ -3,6 +3,7 @@
 This module creates following resources.
 
 - `aws_route53profiles_profile`
+- `aws_route53profiles_resource_association` (optional)
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -23,21 +24,23 @@ This module creates following resources.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.12.0 |
-| <a name="module_share"></a> [share](#module\_share) | tedilabs/organization/aws//modules/ram-share | ~> 0.5.0 |
+| <a name="module_share"></a> [share](#module\_share) | tedilabs/organization/aws//modules/ram-share | ~> 0.8.1 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_route53profiles_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_profile) | resource |
+| [aws_route53profiles_resource_association.resolver_query_log_configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_resource_association) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+|------|-------------|------|---------| :------: |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the Route53 Profile. | `string` | n/a | yes |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | (Optional) The region in which to create the module resources. If not provided, the module resources will be created in the provider's configured region. | `string` | `null` | no |
+| <a name="input_resolver_query_log_configurations"></a> [resolver\_query\_log\_configurations](#input\_resolver\_query\_log\_configurations) | (Optional) A list of configurations to associate Route53 Resolver query logging configurations with the Profile. Each block of `resolver_query_log_configurations` as defined below.<br/>    (Required) `name` - The name of the resource association with the query logging configuration.<br/>    (Required) `resolver_query_log_configuration` - The ARN of the Route53 Resolver query logging configuration to associate with. | <pre>list(object({<br/>    name                             = string<br/>    resolver_query_log_configuration = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_resource_associations"></a> [resource\_associations](#input\_resource\_associations) | (Optional) A list of Route53 resource associations for the Profile. Each value of `resource_associations` as defined below.<br/>    (Required) `name` - The name of the Profile Resource Association.<br/>    (Required) `resource_arn` - The ARN of the resource to be associated with the profile.<br/>    (Optional) `resource_properties` - Resource properties for the resource to be associated with the profile.<br/>    (Optional) `timeouts` - A configuration of timeouts for the resource association. `timeouts` as defined below.<br/>      (Optional) `create` - Timeout for creating the resource association.<br/>      (Optional) `delete` - Timeout for deleting the resource association. | <pre>list(object({<br/>    name                = string<br/>    resource_arn        = string<br/>    resource_properties = optional(string)<br/>    timeouts = optional(object({<br/>      create = optional(string)<br/>      delete = optional(string)<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.<br/>    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.<br/>    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.<br/>    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`. | <pre>object({<br/>    enabled     = optional(bool, true)<br/>    name        = optional(string, "")<br/>    description = optional(string, "Managed by Terraform.")<br/>  })</pre> | `{}` | no |
 | <a name="input_shares"></a> [shares](#input\_shares) | (Optional) A list of resource shares via RAM (Resource Access Manager). | <pre>list(object({<br/>    name = optional(string)<br/><br/>    permissions = optional(set(string), ["AWSRAMPermissionRoute53ProfileAllowAssociation"])<br/><br/>    external_principals_allowed = optional(bool, false)<br/>    principals                  = optional(set(string), [])<br/><br/>    tags = optional(map(string), {})<br/>  }))</pre> | `[]` | no |
@@ -53,6 +56,7 @@ This module creates following resources.
 | <a name="output_name"></a> [name](#output\_name) | The name of the Route53 Profile. |
 | <a name="output_owner_id"></a> [owner\_id](#output\_owner\_id) | The AWS Account ID the account that created the Route53 Profile. |
 | <a name="output_region"></a> [region](#output\_region) | The AWS region this module resources resides in. |
+| <a name="output_resolver_query_log_configurations"></a> [resolver\_query\_log\_configurations](#output\_resolver\_query\_log\_configurations) | A list of Route53 Resolver query logging configuration associations with the Profile. |
 | <a name="output_resource_group"></a> [resource\_group](#output\_resource\_group) | The resource group created to manage resources in this module. |
 | <a name="output_sharing"></a> [sharing](#output\_sharing) | The configuration for sharing of the Route53 profile.<br/>    `status` - An indication of whether the profile is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`.<br/>    `shares` - The list of resource shares via RAM (Resource Access Manager). |
 | <a name="output_status"></a> [status](#output\_status) | The status of the Route53 Profile. |

--- a/modules/profile/associations.tf
+++ b/modules/profile/associations.tf
@@ -1,0 +1,19 @@
+###################################################
+# Associations with Resolver Query Log Configurations
+###################################################
+
+# INFO: Not supported attributes
+# - `resource_properties`
+resource "aws_route53profiles_resource_association" "resolver_query_log_configurations" {
+  for_each = {
+    for config in var.resolver_query_log_configurations :
+    config.name => config
+  }
+
+  region = aws_route53profiles_profile.this.region
+
+  profile_id = aws_route53profiles_profile.this.id
+
+  name         = each.key
+  resource_arn = each.value.resolver_query_log_configuration
+}

--- a/modules/profile/outputs.tf
+++ b/modules/profile/outputs.tf
@@ -33,6 +33,23 @@ output "status_message" {
   value       = aws_route53profiles_profile.this.status_message
 }
 
+output "resolver_query_log_configurations" {
+  description = "A list of Route53 Resolver query logging configuration associations with the Profile."
+  value = [
+    for assoc in aws_route53profiles_resource_association.resolver_query_log_configurations : {
+      id       = assoc.id
+      name     = assoc.name
+      owner_id = assoc.owner_id
+      status   = assoc.status
+      resource = {
+        type       = assoc.resource_type
+        arn        = assoc.resource_arn
+        properties = assoc.resource_properties
+      }
+    }
+  ]
+}
+
 output "resource_group" {
   description = "The resource group created to manage resources in this module."
   value = merge(

--- a/modules/profile/variables.tf
+++ b/modules/profile/variables.tf
@@ -42,6 +42,20 @@ variable "resource_associations" {
   }
 }
 
+variable "resolver_query_log_configurations" {
+  description = <<EOF
+  (Optional) A list of configurations to associate Route53 Resolver query logging configurations with the Profile. Each block of `resolver_query_log_configurations` as defined below.
+    (Required) `name` - The name of the resource association with the query logging configuration.
+    (Required) `resolver_query_log_configuration` - The ARN of the Route53 Resolver query logging configuration to associate with.
+  EOF
+  type = list(object({
+    name                             = string
+    resolver_query_log_configuration = string
+  }))
+  default  = []
+  nullable = false
+}
+
 variable "timeouts" {
   description = <<EOF
   (Optional) How long to wait for the Profile to be created/read/deleted.


### PR DESCRIPTION
## What & why

Route53 Profile can hold Resolver query logging configurations as associated resources, but the `profile` module only managed the profile itself. This adds the association from the profile side, mirroring the profile-side association added to `resolver-query-logging` in #82.

## Changes

| File | Change |
|------|--------|
| `modules/profile/associations.tf` | New `aws_route53profiles_resource_association.resolver_query_log_configurations` resource, keyed by association name. `resource_properties` is intentionally not exposed. |
| `modules/profile/variables.tf` | New `resolver_query_log_configurations` input (`name`, `resolver_query_log_configuration` ARN). |
| `modules/profile/outputs.tf` | New `resolver_query_log_configurations` output with `id`, `name`, `owner_id`, `status`, and `resource` (`type`, `arn`, `properties`). |
| `modules/profile/README.md` | Resource list and terraform-docs regenerated. The `share` module version line now reflects `~> 0.8.1` from #80. |

### Notes

- The pre-existing `resource_associations` input is still declared but not consumed by any resource. Left untouched here; can be removed or wired in a follow-up.

## Verification

- `terraform fmt -check`: pass
- `terraform init -backend=false && terraform validate`: pass
- `tflint --config .tflint.hcl`: pass
- `terraform-docs markdown table --sort-by required`: regenerated, cosmetic table-separator and provider-version churn restored
- Not verified: no live `terraform plan`/`apply` against an AWS account.