### PR TITLE
feat(profile): support dns firewall rule group associations

### DIFF
--- a/modules/profile/README.md
+++ b/modules/profile/README.md
@@ -31,6 +31,7 @@ This module creates following resources.
 | Name | Type |
 |------|------|
 | [aws_route53profiles_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_profile) | resource |
+| [aws_route53profiles_resource_association.dns_firewall_rule_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_resource_association) | resource |
 | [aws_route53profiles_resource_association.resolver_query_log_configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_resource_association) | resource |
 
 ## Inputs
@@ -38,6 +39,7 @@ This module creates following resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------| :------: |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the Route53 Profile. | `string` | n/a | yes |
+| <a name="input_dns_firewall_rule_groups"></a> [dns\_firewall\_rule\_groups](#input\_dns\_firewall\_rule\_groups) | (Optional) A list of configurations to associate Route53 Resolver DNS Firewall rule groups with the Profile. Each block of `dns_firewall_rule_groups` as defined below.<br/>    (Required) `name` - The name of the resource association with the DNS Firewall rule group.<br/>    (Required) `dns_firewall_rule_group` - The ARN of the Route53 Resolver DNS Firewall rule group to associate with.<br/>    (Required) `priority` - The setting that determines the processing order of the rule group among the rule groups associated with the Profile. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting. Valid values are between `100` and `9900`. | <pre>list(object({<br/>    name                    = string<br/>    dns_firewall_rule_group = string<br/>    priority                = number<br/>  }))</pre> | `[]` | no |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | (Optional) The region in which to create the module resources. If not provided, the module resources will be created in the provider's configured region. | `string` | `null` | no |
 | <a name="input_resolver_query_log_configurations"></a> [resolver\_query\_log\_configurations](#input\_resolver\_query\_log\_configurations) | (Optional) A list of configurations to associate Route53 Resolver query logging configurations with the Profile. Each block of `resolver_query_log_configurations` as defined below.<br/>    (Required) `name` - The name of the resource association with the query logging configuration.<br/>    (Required) `resolver_query_log_configuration` - The ARN of the Route53 Resolver query logging configuration to associate with. | <pre>list(object({<br/>    name                             = string<br/>    resolver_query_log_configuration = string<br/>  }))</pre> | `[]` | no |
@@ -51,6 +53,7 @@ This module creates following resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the Route53 Profile. |
+| <a name="output_dns_firewall_rule_groups"></a> [dns\_firewall\_rule\_groups](#output\_dns\_firewall\_rule\_groups) | A list of Route53 Resolver DNS Firewall rule group associations with the Profile. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of the Route53 Profile. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the Route53 Profile. |
 | <a name="output_owner_id"></a> [owner\_id](#output\_owner\_id) | The AWS Account ID the account that created the Route53 Profile. |

--- a/modules/profile/associations.tf
+++ b/modules/profile/associations.tf
@@ -17,3 +17,25 @@ resource "aws_route53profiles_resource_association" "resolver_query_log_configur
   name         = each.key
   resource_arn = each.value.resolver_query_log_configuration
 }
+
+
+###################################################
+# Associations with DNS Firewall Rule Groups
+###################################################
+
+resource "aws_route53profiles_resource_association" "dns_firewall_rule_groups" {
+  for_each = {
+    for rule_group in var.dns_firewall_rule_groups :
+    rule_group.name => rule_group
+  }
+
+  region = aws_route53profiles_profile.this.region
+
+  profile_id = aws_route53profiles_profile.this.id
+
+  name         = each.key
+  resource_arn = each.value.dns_firewall_rule_group
+  resource_properties = jsonencode({
+    priority = each.value.priority
+  })
+}

--- a/modules/profile/outputs.tf
+++ b/modules/profile/outputs.tf
@@ -50,6 +50,24 @@ output "resolver_query_log_configurations" {
   ]
 }
 
+output "dns_firewall_rule_groups" {
+  description = "A list of Route53 Resolver DNS Firewall rule group associations with the Profile."
+  value = [
+    for assoc in aws_route53profiles_resource_association.dns_firewall_rule_groups : {
+      id       = assoc.id
+      name     = assoc.name
+      owner_id = assoc.owner_id
+      status   = assoc.status
+      priority = jsondecode(assoc.resource_properties).priority
+      resource = {
+        type       = assoc.resource_type
+        arn        = assoc.resource_arn
+        properties = assoc.resource_properties
+      }
+    }
+  ]
+}
+
 output "resource_group" {
   description = "The resource group created to manage resources in this module."
   value = merge(

--- a/modules/profile/variables.tf
+++ b/modules/profile/variables.tf
@@ -25,6 +25,30 @@ variable "resolver_query_log_configurations" {
   nullable = false
 }
 
+variable "dns_firewall_rule_groups" {
+  description = <<EOF
+  (Optional) A list of configurations to associate Route53 Resolver DNS Firewall rule groups with the Profile. Each block of `dns_firewall_rule_groups` as defined below.
+    (Required) `name` - The name of the resource association with the DNS Firewall rule group.
+    (Required) `dns_firewall_rule_group` - The ARN of the Route53 Resolver DNS Firewall rule group to associate with.
+    (Required) `priority` - The setting that determines the processing order of the rule group among the rule groups associated with the Profile. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting. Valid values are between `100` and `9900`.
+  EOF
+  type = list(object({
+    name                    = string
+    dns_firewall_rule_group = string
+    priority                = number
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition = alltrue([
+      for rule_group in var.dns_firewall_rule_groups :
+      rule_group.priority >= 100 && rule_group.priority <= 9900
+    ])
+    error_message = "Valid values for `priority` are between `100` and `9900`."
+  }
+}
+
 variable "timeouts" {
   description = <<EOF
   (Optional) How long to wait for the Profile to be created/read/deleted.


### PR DESCRIPTION
## What & why

Route53 Profile can hold Resolver DNS Firewall rule groups as associated resources. This adds the association from the profile side, following the same shape as `resolver_query_log_configurations` from #83.

Unlike query logging configurations, a DNS Firewall rule group association requires a processing priority passed via `resource_properties` as `{"priority": N}`, with valid values between 100 and 9900. Source: Route 53 Developer Guide, "Associate DNS Firewall rule groups to a Route 53 Profile", and the Route53Profiles `AssociateResourceToProfile` API reference.

## Changes

| File | Change |
|------|--------|
| `modules/profile/associations.tf` | New `aws_route53profiles_resource_association.dns_firewall_rule_groups` resource, keyed by association name. `resource_properties` is set to `jsonencode({ priority = ... })`. |
| `modules/profile/variables.tf` | New `dns_firewall_rule_groups` input (`name`, `dns_firewall_rule_group` ARN, `priority`). Validation enforces `100 <= priority <= 9900`. |
| `modules/profile/outputs.tf` | New `dns_firewall_rule_groups` output with `id`, `name`, `owner_id`, `status`, decoded `priority`, and `resource` (`type`, `arn`, `properties`). |
| `modules/profile/README.md` | terraform-docs regenerated. |

## Verification

- `terraform fmt -check`: pass
- `terraform init -backend=false && terraform validate`: pass
- `tflint --config .tflint.hcl`: pass
- `terraform-docs markdown table --sort-by required`: regenerated, cosmetic table-separator and provider-version churn restored
- Not verified: no live `terraform plan`/`apply` against an AWS account. In particular, whether the provider reports a perpetual diff on `resource_properties` (e.g. whitespace normalization of the JSON string returned by the API) has not been checked against a real profile.